### PR TITLE
Version 1.16 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ function loader (mcVersion) {
   const Window = require('./lib/Window')(Item)
 
   let windows
-  if (mcVersion.startsWith('1.14') || mcVersion.startsWith('1.15')) {
+  if (mcVersion.startsWith('1.14') || mcVersion.startsWith('1.15') || mcVersion.startsWith('1.16')) {
     // https://wiki.vg/Inventory
     windows = {
       'minecraft:inventory': { type: -1, inventory: { start: 9, end: 44 }, slots: 46, craft: 0, requireConfirmation: true },


### PR DESCRIPTION
Added:
 || mcVersion.startsWith('1.16')

Reason:
  This allows inventory to work with version Minecraft v1.16 in some form.