### PR TITLE
Remove window.containerItems() form README.md and add ability to find items by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,6 @@ Returns how many items there are in the top section of the window.
  * `metadata` - (optional) metadata value that you are looking for.
    defaults to unspecified
 
-#### window.containerItems()
-
-Returns a list of `Item` instances from the top section of the window.
-
 ## History
 
 ### 1.5.0

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Map of slot index to `Item` instance.
 
 In vanilla client, this is the item you are holding with the mouse cursor.
 
-#### window.findInventoryItem(itemType, metadata, [notFull])
+#### window.findInventoryItem(item, metadata, [notFull])
 
- * `itemType` - numerical id that you are looking for
+ * `item` - numerical id or name that you are looking for
  * `metadata` -  metadata value that you are looking for. `null`
    means unspecified.
  * `notFull` - (optional) - if `true`, means that the returned

--- a/lib/Window.js
+++ b/lib/Window.js
@@ -153,8 +153,23 @@ module.exports = (Item) => {
       return null
     }
 
-    findInventoryItem (itemType, metadata, notFull) {
-      return this.findItemRange(this.inventoryStart, this.inventoryEnd, itemType, metadata, notFull)
+    findItemRangeName (start, end, itemName, metadata, notFull) {
+      assert.notStrictEqual(itemName, null)
+      for (let i = start; i < end; ++i) {
+        const item = this.slots[i]
+        if (item && itemName === item.name &&
+          (metadata == null || metadata === item.metadata) &&
+          (!notFull || item.count < item.stackSize)) {
+          return item
+        }
+      }
+      return null
+    }
+
+    findInventoryItem (item, metadata, notFull) {
+      assert(typeof item === 'number' || typeof item === 'string' || typeof item === 'undefined', 'No valid type given')
+      return typeof item === 'number' ? this.findItemRange(this.inventoryStart, this.inventoryEnd, item, metadata, notFull)
+        : this.findItemRangeName(this.inventoryStart, this.inventoryEnd, item, metadata, notFull)
     }
 
     firstEmptySlotRange (start, end) {


### PR DESCRIPTION
Edit: I wanted to do 2 separate pull-requests for these separate commits, but I guess that is not possible.

I think it could be quite useful if we could also search items in an window by their name instead of only their type.