### PR TITLE
fix ts error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -187,7 +187,7 @@ declare class Window extends EventEmitter {
      * @param blockId (optional) numerical id of the block that you would like to clear
      * @param count (optional, requires blockId) only delete this number of the given block
      */
-    clear(blockId?, count?): void;
+    clear(blockId?: number, count?: number): void;
 }
 declare interface Click {
     mode: number;


### PR DESCRIPTION
clear did not have types for its arguments, which causes typescript parser errors