### PR TITLE
Avoid emitting references

### DIFF
--- a/lib/Window.js
+++ b/lib/Window.js
@@ -138,8 +138,8 @@ module.exports = (Item) => {
       if (newItem) newItem.slot = slot
       const oldItem = this.slots[slot]
       this.slots[slot] = newItem
-      this.emit('updateSlot', slot, oldItem, newItem)
-      this.emit(`updateSlot:${slot}`, oldItem, newItem)
+      this.emit('updateSlot', slot, { ...oldItem }, { ...newItem })
+      this.emit(`updateSlot:${slot}`, { ...oldItem }, { ...newItem })
     }
 
     findItemRange (start, end, itemType, metadata, notFull, nbt) {


### PR DESCRIPTION
While working on https://github.com/imharvol/mineflayer-web-inventory/issues/20 I noticed that the 'updateSlot' was emitting oldItem and newItem as references that I wasn't accounting for.

I don't think emitting references is the right behavior. But if it is, it should be specified on the docs.

Sorry if I'm not using the term references correctly, I'm not used to think about those on JS.