### PR TITLE
Fix empty object emitting

### DIFF
--- a/lib/Window.js
+++ b/lib/Window.js
@@ -147,8 +147,11 @@ module.exports = (Item) => {
       if (newItem) newItem.slot = slot
       const oldItem = this.slots[slot]
       this.slots[slot] = newItem
-      this.emit('updateSlot', slot, { ...oldItem }, { ...newItem })
-      this.emit(`updateSlot:${slot}`, { ...oldItem }, { ...newItem })
+
+      const copyNewItem = newItem ? { ...newItem } : null
+      const copyOldItem = oldItem ? { ...oldItem } : null
+      this.emit('updateSlot', slot, copyOldItem, copyNewItem)
+      this.emit(`updateSlot:${slot}`, copyOldItem, copyNewItem)
     }
 
     findItemRange (start, end, itemType, metadata, notFull, nbt) {


### PR DESCRIPTION
Aparently https://github.com/PrismarineJS/prismarine-windows/pull/41 despite passing mineflayer's tests, it did broke something, and it was precisely mineflayer-web-inventory!
By emitting { ...oldItem } if oldItem was null, we would be emitting an empty object. My bad, this PR fixes that.

This probably deserves a new release ASAP.