### PR TITLE
Comment assertion check to fix 1.12.2

### DIFF
--- a/lib/Window.js
+++ b/lib/Window.js
@@ -271,7 +271,7 @@ module.exports = (Item) => {
     acceptCraftingClick (click) {
       assert.strictEqual(click.mouseButton, 0)
       assert.strictEqual(click.mode, 0)
-      assert.strictEqual(this.selectedItem, null)
+      // assert.strictEqual(this.selectedItem, null) // This breaks clicking on the crafting grid result item on 1.12.2 Vanilla and paper. Vanilla and paper 1.12.2 servers put items into the output slot so we expect an item to be there that can be picked up after we clicked it to craft the crafting item. This should check against the item we picked up not against null.
       return this.acceptNonInventorySwapAreaClick(click)
     }
 


### PR DESCRIPTION
This fixes a wrong assertion check when crafting in 1.12.2 by manually clicking on the result slot. There is a very high chance this will break other versions. I have not tested it.